### PR TITLE
PHP 8 Fix

### DIFF
--- a/src/SmartCAT/API/Normalizer/DocumentModelNormalizer.php
+++ b/src/SmartCAT/API/Normalizer/DocumentModelNormalizer.php
@@ -25,6 +25,32 @@ class DocumentModelNormalizer extends AbstractNormalizer
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         $object = new \SmartCat\Client\Model\DocumentModel();
+        $data = (array) $data;
+        $properties = ['id', 'name', 'creationDate', 'deadline', 'sourceLanguage', 'documentDisassemblingStatus', 'targetLanguage', 'status', 'wordsCount', 'pretranslateCompleted', 'workflowStages', 'externalId', 'metaInfo', 'placeholdersAreEnabled'];
+
+        foreach ($properties as $property) {
+            if (isset($data[$property])) {
+                if (is_array($data[$property])) {                    
+                    $values = [];
+                    foreach ($data[$property] as $value) {                        
+                        if ($property == 'workflowStages') {
+                            $values[] = $this->serializer->deserialize(json_encode($value), 'SmartCat\\Client\\Model\\DocumentWorkflowStageModel', 'json', $context);
+                        } else {
+                            $values[] = $value;
+                        }
+                    }
+                    $setter = 'set' . ucfirst($property);
+                    $object->$setter($values);
+                } else {
+                    $setter = 'set' . ucfirst($property);
+                    $object->$setter($data[$property]);
+                }
+            }
+        }
+
+        return $object;        
+
+        $object = new \SmartCat\Client\Model\DocumentModel();
         if (property_exists($data, 'id')) {
             $object->setId($data->{'id'});
         }

--- a/src/SmartCAT/API/Normalizer/DocumentModelNormalizer.php
+++ b/src/SmartCAT/API/Normalizer/DocumentModelNormalizer.php
@@ -26,7 +26,7 @@ class DocumentModelNormalizer extends AbstractNormalizer
     {
         $object = new \SmartCat\Client\Model\DocumentModel();
         $data = (array) $data;
-        $properties = ['id', 'name', 'creationDate', 'deadline', 'sourceLanguage', 'documentDisassemblingStatus', 'targetLanguage', 'status', 'wordsCount', 'pretranslateCompleted', 'workflowStages', 'externalId', 'metaInfo', 'placeholdersAreEnabled'];
+        $properties = ['id', 'name', 'creationDate', 'deadline', 'sourceLanguage', 'documentDisassemblingStatus', 'targetLanguage', 'status', 'wordsCount', 'statusModificationDate', 'pretranslateCompleted', 'workflowStages', 'externalId', 'metaInfo', 'placeholdersAreEnabled'];
 
         foreach ($properties as $property) {
             if (isset($data[$property])) {
@@ -48,58 +48,6 @@ class DocumentModelNormalizer extends AbstractNormalizer
             }
         }
 
-        return $object;        
-
-        $object = new \SmartCat\Client\Model\DocumentModel();
-        if (property_exists($data, 'id')) {
-            $object->setId($data->{'id'});
-        }
-        if (property_exists($data, 'name')) {
-            $object->setName($data->{'name'});
-        }
-        if (property_exists($data, 'creationDate')) {
-            $object->setCreationDate($data->{'creationDate'});
-        }
-        if (property_exists($data, 'deadline')) {
-            $object->setDeadline($data->{'deadline'});
-        }
-        if (property_exists($data, 'sourceLanguage')) {
-            $object->setSourceLanguage($data->{'sourceLanguage'});
-        }
-        if (property_exists($data, 'documentDisassemblingStatus')) {
-            $object->setDocumentDisassemblingStatus($data->{'documentDisassemblingStatus'});
-        }
-        if (property_exists($data, 'targetLanguage')) {
-            $object->setTargetLanguage($data->{'targetLanguage'});
-        }
-        if (property_exists($data, 'status')) {
-            $object->setStatus($data->{'status'});
-        }
-        if (property_exists($data, 'wordsCount')) {
-            $object->setWordsCount($data->{'wordsCount'});
-        }
-        if (property_exists($data, 'statusModificationDate')) {
-            $object->setStatusModificationDate($data->{'statusModificationDate'});
-        }
-        if (property_exists($data, 'pretranslateCompleted')) {
-            $object->setPretranslateCompleted($data->{'pretranslateCompleted'});
-        }
-        if (property_exists($data, 'workflowStages')) {
-            $values = array();
-            foreach ($data->{'workflowStages'} as $value) {
-                $values[] = $this->serializer->deserialize(json_encode($value), 'SmartCat\\Client\\Model\\DocumentWorkflowStageModel', 'json', $context);
-            }
-            $object->setWorkflowStages($values);
-        }
-        if (property_exists($data, 'externalId')) {
-            $object->setExternalId($data->{'externalId'});
-        }
-        if (property_exists($data, 'metaInfo')) {
-            $object->setMetaInfo($data->{'metaInfo'});
-        }
-        if (property_exists($data, 'placeholdersAreEnabled')) {
-            $object->setPlaceholdersAreEnabled($data->{'placeholdersAreEnabled'});
-        }
         return $object;
     }
 

--- a/src/SmartCAT/API/Normalizer/DocumentWorkflowStageModelNormalizer.php
+++ b/src/SmartCAT/API/Normalizer/DocumentWorkflowStageModelNormalizer.php
@@ -23,6 +23,33 @@ class DocumentWorkflowStageModelNormalizer extends AbstractNormalizer
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         $object = new \SmartCat\Client\Model\DocumentWorkflowStageModel();
+        $data = (array) $data;
+
+        $properties = ['progress', 'wordsTranslated', 'unassignedWordsCount', 'status', 'executives'];
+
+        foreach ($properties as $property) {
+            if (isset($data[$property])) {
+                if (is_array($data[$property])) {                    
+                    $values = [];
+                    foreach ($data[$property] as $value) {                        
+                        if ($property == 'executives') {
+                            $values[] = $this->serializer->deserialize(json_encode($value), 'SmartCat\\Client\\Model\\AssignedExecutiveModel', 'json', $context);
+                        } else {
+                            $values[] = $value;
+                        }
+                    }
+                    $setter = 'set' . ucfirst($property);
+                    $object->$setter($values);
+                } else {
+                    $setter = 'set' . ucfirst($property);
+                    $object->$setter($data[$property]);
+                }
+            }
+        }
+
+        return $object;         
+
+        $object = new \SmartCat\Client\Model\DocumentWorkflowStageModel();
         if (property_exists($data, 'progress')) {
             $object->setProgress($data->{'progress'});
         }

--- a/src/SmartCAT/API/Normalizer/DocumentWorkflowStageModelNormalizer.php
+++ b/src/SmartCAT/API/Normalizer/DocumentWorkflowStageModelNormalizer.php
@@ -47,28 +47,6 @@ class DocumentWorkflowStageModelNormalizer extends AbstractNormalizer
             }
         }
 
-        return $object;         
-
-        $object = new \SmartCat\Client\Model\DocumentWorkflowStageModel();
-        if (property_exists($data, 'progress')) {
-            $object->setProgress($data->{'progress'});
-        }
-        if (property_exists($data, 'wordsTranslated')) {
-            $object->setWordsTranslated($data->{'wordsTranslated'});
-        }
-        if (property_exists($data, 'unassignedWordsCount')) {
-            $object->setUnassignedWordsCount($data->{'unassignedWordsCount'});
-        }
-        if (property_exists($data, 'status')) {
-            $object->setStatus($data->{'status'});
-        }
-        if (property_exists($data, 'executives')) {
-            $values = array();
-            foreach ($data->{'executives'} as $value) {
-                $values[] = $this->serializer->deserialize(json_encode($value), 'SmartCat\\Client\\Model\\AssignedExecutiveModel', 'json', $context);
-            }
-            $object->setExecutives($values);
-        }
         return $object;
     }
 

--- a/src/SmartCAT/API/Normalizer/ProjectModelNormalizer.php
+++ b/src/SmartCAT/API/Normalizer/ProjectModelNormalizer.php
@@ -47,6 +47,36 @@ class ProjectModelNormalizer extends AbstractNormalizer
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         $object = new \SmartCat\Client\Model\ProjectModel();
+        $data = (array) $data;
+        $properties = ['id', 'name', 'description', 'deadline', 'creationDate', 'createdByUserId', 'sourceLanguage', 'targetLanguages', 'status', 'statusModificationDate', 'domainId', 'clientId', 'vendors', 'workflowStages', 'documents', 'externalTag'];
+
+        foreach ($properties as $property) {
+            if (isset($data[$property])) {
+                if (is_array($data[$property])) {                    
+                    $values = [];
+                    foreach ($data[$property] as $value) {                        
+                        if ($property == 'vendors') {                            
+                            $values[] = $this->serializer->deserialize(json_encode($value), ProjectVendorModel::class, 'json', $context);
+                        } elseif ($property == 'workflowStages') {
+                            $values[] = $this->serializer->deserialize(json_encode($value), ProjectWorkflowStageModel::class, 'json', $context);
+                        } elseif ($property == 'documents') {
+                            $values[] = $this->serializer->deserialize(json_encode($value), DocumentModel::class, 'json', $context);
+                        } else {
+                            $values[] = $value;
+                        }
+                    }
+                    $setter = 'set' . ucfirst($property);
+                    $object->$setter($values);
+                } else {
+                    $setter = 'set' . ucfirst($property);
+                    $object->$setter($data[$property]);
+                }
+            }
+        }
+
+        return $object;        
+
+        $object = new \SmartCat\Client\Model\ProjectModel();
         if (property_exists($data, 'id')) {
             $object->setId($data->{'id'});
         }

--- a/src/SmartCAT/API/Normalizer/ProjectModelNormalizer.php
+++ b/src/SmartCAT/API/Normalizer/ProjectModelNormalizer.php
@@ -48,7 +48,7 @@ class ProjectModelNormalizer extends AbstractNormalizer
     {
         $object = new \SmartCat\Client\Model\ProjectModel();
         $data = (array) $data;
-        $properties = ['id', 'name', 'description', 'deadline', 'creationDate', 'createdByUserId', 'sourceLanguage', 'targetLanguages', 'status', 'statusModificationDate', 'domainId', 'clientId', 'vendors', 'workflowStages', 'documents', 'externalTag'];
+        $properties = ['id', 'name', 'description', 'deadline', 'creationDate', 'createdByUserId', 'modificationDate', 'sourceLanguage', 'targetLanguages', 'status', 'statusModificationDate', 'domainId', 'clientId', 'vendors', 'workflowStages', 'documents', 'externalTag'];
 
         foreach ($properties as $property) {
             if (isset($data[$property])) {
@@ -72,77 +72,6 @@ class ProjectModelNormalizer extends AbstractNormalizer
                     $object->$setter($data[$property]);
                 }
             }
-        }
-
-        return $object;        
-
-        $object = new \SmartCat\Client\Model\ProjectModel();
-        if (property_exists($data, 'id')) {
-            $object->setId($data->{'id'});
-        }
-        if (property_exists($data, 'name')) {
-            $object->setName($data->{'name'});
-        }
-        if (property_exists($data, 'description')) {
-            $object->setDescription($data->{'description'});
-        }
-        if (property_exists($data, 'deadline')) {
-            $object->setDeadline($data->{'deadline'});
-        }
-        if (property_exists($data, 'creationDate')) {
-            $object->setCreationDate($data->{'creationDate'});
-        }
-        if (property_exists($data, 'createdByUserId')) {
-            $object->setCreatedByUserId($data->{'createdByUserId'});
-        }
-        if (property_exists($data, 'modificationDate')) {
-            $object->setModificationDate($data->{'modificationDate'});
-        }
-        if (property_exists($data, 'sourceLanguage')) {
-            $object->setSourceLanguage($data->{'sourceLanguage'});
-        }
-        if (property_exists($data, 'targetLanguages')) {
-            $values = array();
-            foreach ($data->{'targetLanguages'} as $value) {
-                $values[] = $value;
-            }
-            $object->setTargetLanguages($values);
-        }
-        if (property_exists($data, 'status')) {
-            $object->setStatus($data->{'status'});
-        }
-        if (property_exists($data, 'statusModificationDate')) {
-            $object->setStatusModificationDate($data->{'statusModificationDate'});
-        }
-        if (property_exists($data, 'domainId')) {
-            $object->setDomainId($data->{'domainId'});
-        }
-        if (property_exists($data, 'clientId')) {
-            $object->setClientId($data->{'clientId'});
-        }
-        if (property_exists($data, 'vendors')) {
-            $values_3 = array();
-            foreach ($data->{'vendors'} as $value_3) {
-                $values_3[] = $this->serializer->deserialize(json_encode($value_3), ProjectVendorModel::class, 'json', $context);
-            }
-            $object->setVendors($values_3);
-        }
-        if (property_exists($data, 'workflowStages')) {
-            $values_1 = array();
-            foreach ($data->{'workflowStages'} as $value_1) {
-                $values_1[] = $this->serializer->deserialize(json_encode($value_1), ProjectWorkflowStageModel::class, 'json', $context);
-            }
-            $object->setWorkflowStages($values_1);
-        }
-        if (property_exists($data, 'documents')) {
-            $values_2 = array();
-            foreach ($data->{'documents'} as $value_2) {
-                $values_2[] = $this->serializer->deserialize(json_encode($value_2), DocumentModel::class, 'json', $context);
-            }
-            $object->setDocuments($values_2);
-        }
-        if (property_exists($data, 'externalTag')) {
-            $object->setExternalTag($data->{'externalTag'});
         }
 
         return $object;

--- a/src/SmartCAT/API/Normalizer/ProjectWorkflowStageModelNormalizer.php
+++ b/src/SmartCAT/API/Normalizer/ProjectWorkflowStageModelNormalizer.php
@@ -23,6 +23,18 @@ class ProjectWorkflowStageModelNormalizer extends AbstractNormalizer
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         $object = new \SmartCat\Client\Model\ProjectWorkflowStageModel();
+        $data = (array) $data;
+        $properties = ['progress', 'stageType'];
+
+        foreach ($properties as $property) {
+            if (isset($data[$property])) {
+                $object->{'set' . ucfirst($property)}($data[$property]);
+            }
+        }
+
+        return $object;        
+
+        $object = new \SmartCat\Client\Model\ProjectWorkflowStageModel();
         if (property_exists($data, 'progress')) {
             $object->setProgress($data->{'progress'});
         }

--- a/src/SmartCAT/API/Normalizer/ProjectWorkflowStageModelNormalizer.php
+++ b/src/SmartCAT/API/Normalizer/ProjectWorkflowStageModelNormalizer.php
@@ -32,15 +32,6 @@ class ProjectWorkflowStageModelNormalizer extends AbstractNormalizer
             }
         }
 
-        return $object;        
-
-        $object = new \SmartCat\Client\Model\ProjectWorkflowStageModel();
-        if (property_exists($data, 'progress')) {
-            $object->setProgress($data->{'progress'});
-        }
-        if (property_exists($data, 'stageType')) {
-            $object->setStageType($data->{'stageType'});
-        }
         return $object;
     }
 


### PR DESCRIPTION
Upgraded to PHP 8, and had a couple of errors on the Normaliser Classes. Here's an example:

property_exists(): Argument #1 ($object_or_class) must be of type object|string, array given at /vendor/smartcat/smartcat-api/src/SmartCAT/API/Normalizer/ProjectModelNormalizer.php:50

I understand this was due to an upgrade to PHP 8.

So I've rewritten the function temporarily, and urge you to review and find a permanent fix.
